### PR TITLE
Fix cached results bug

### DIFF
--- a/docker/nostpy_relay/event_handler.py
+++ b/docker/nostpy_relay/event_handler.py
@@ -3,7 +3,7 @@ import json
 import logging
 import os
 from contextlib import asynccontextmanager
-from typing import Iterable, Callable, Dict, List
+from typing import Iterable, Callable, Dict, List, Any
 
 import psycopg
 import redis
@@ -278,11 +278,15 @@ async def handle_subscription(request: Request) -> JSONResponse:
         )
         logger.debug(f"Cached results are {cached_results}")
 
-        sql_query = subscription_obj.base_query_builder(
-            tag_values, query_parts, limit, global_search, logger
-        )
+        if cached_results:
+            return subscription_obj.sub_response_builder(
+                "EVENT", subscription_obj.subscription_id, cached_results, 200
+            )
 
-        if cached_results is None:
+        elif cached_results is None:
+            sql_query = subscription_obj.base_query_builder(
+                tag_values, query_parts, limit, global_search, logger
+            )
             query_results = await execute_sql_with_tracing(
                 app, sql_query, "SELECT * FROM EVENTS"
             )

--- a/docker/nostpy_relay/event_handler.py
+++ b/docker/nostpy_relay/event_handler.py
@@ -279,11 +279,11 @@ async def handle_subscription(request: Request) -> JSONResponse:
         logger.debug(f"Cached results are {cached_results}")
 
         if cached_results:
-            #utf8_cache = json.loads(cached_results.decode('utf-8'))
-            #dumped_res = json.dumps(utf8_cache)
-            logger.debug(f"Cache utf = {cached_results.decode('utf-8')}")
             return subscription_obj.sub_response_builder(
-                "EVENT", subscription_obj.subscription_id, cached_results.decode('utf-8'), 200
+                "EVENT",
+                subscription_obj.subscription_id,
+                cached_results.decode("utf-8"),
+                200,
             )
 
         elif cached_results is None:

--- a/docker/nostpy_relay/event_handler.py
+++ b/docker/nostpy_relay/event_handler.py
@@ -280,9 +280,10 @@ async def handle_subscription(request: Request) -> JSONResponse:
 
         if cached_results:
             utf8_cache = json.loads(cached_results.decode('utf-8'))
-            logger.debug(f"UTF-8 decode is {utf8_cache[0]}")
+            dumped = json.dumps(utf8_cache[0])
+            logger.debug(f"UTF-8 decode is {dumped}")
             return subscription_obj.sub_response_builder(
-                "EVENT", subscription_obj.subscription_id, utf8_cache[0], 200
+                "EVENT", subscription_obj.subscription_id, dumped, 200
             )
 
         elif cached_results is None:

--- a/docker/nostpy_relay/event_handler.py
+++ b/docker/nostpy_relay/event_handler.py
@@ -281,9 +281,10 @@ async def handle_subscription(request: Request) -> JSONResponse:
         if cached_results:
             utf8_cache = json.loads(cached_results.decode('utf-8'))
             dumped = json.dumps(utf8_cache[0])
-            logger.debug(f"UTF-8 decode is {dumped}")
+            loaded = json.loads(dumped)
+            logger.debug(f"UTF-8 decode is {loaded}")
             return subscription_obj.sub_response_builder(
-                "EVENT", subscription_obj.subscription_id, dumped, 200
+                "EVENT", subscription_obj.subscription_id, loaded, 200
             )
 
         elif cached_results is None:

--- a/docker/nostpy_relay/event_handler.py
+++ b/docker/nostpy_relay/event_handler.py
@@ -279,11 +279,10 @@ async def handle_subscription(request: Request) -> JSONResponse:
         logger.debug(f"Cached results are {cached_results}")
 
         if cached_results:
-            utf8_cache = json.loads(cached_results.decode('utf-8'))
-            dumped = json.dumps(utf8_cache)
-            logger.debug(f"UTF-8 decode is {dumped}")
+            #utf8_cache = json.loads(cached_results.decode('utf-8'))
+            #dumped_res = json.dumps(utf8_cache)
             return subscription_obj.sub_response_builder(
-                "EVENT", subscription_obj.subscription_id, dumped, 200
+                "EVENT", subscription_obj.subscription_id, cached_results.decode('utf-8'), 200
             )
 
         elif cached_results is None:

--- a/docker/nostpy_relay/event_handler.py
+++ b/docker/nostpy_relay/event_handler.py
@@ -280,9 +280,9 @@ async def handle_subscription(request: Request) -> JSONResponse:
 
         if cached_results:
             utf8_cache = json.loads(cached_results.decode('utf-8'))
-            logger.debug(f"UTF-8 decode is {utf8_cache}")
+            logger.debug(f"UTF-8 decode is {utf8_cache[0]}")
             return subscription_obj.sub_response_builder(
-                "EVENT", subscription_obj.subscription_id, utf8_cache, 200
+                "EVENT", subscription_obj.subscription_id, utf8_cache[0], 200
             )
 
         elif cached_results is None:

--- a/docker/nostpy_relay/event_handler.py
+++ b/docker/nostpy_relay/event_handler.py
@@ -28,7 +28,7 @@ from init_db import initialize_db
 
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
+logger.setLevel(logging.DEBUG)
 formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
 handler = logging.StreamHandler()
 handler.setFormatter(formatter)

--- a/docker/nostpy_relay/event_handler.py
+++ b/docker/nostpy_relay/event_handler.py
@@ -281,6 +281,7 @@ async def handle_subscription(request: Request) -> JSONResponse:
         if cached_results:
             #utf8_cache = json.loads(cached_results.decode('utf-8'))
             #dumped_res = json.dumps(utf8_cache)
+            logger.debug(f"Cache utf = {cached_results.decode('utf-8')}")
             return subscription_obj.sub_response_builder(
                 "EVENT", subscription_obj.subscription_id, cached_results.decode('utf-8'), 200
             )

--- a/docker/nostpy_relay/event_handler.py
+++ b/docker/nostpy_relay/event_handler.py
@@ -280,11 +280,10 @@ async def handle_subscription(request: Request) -> JSONResponse:
 
         if cached_results:
             utf8_cache = json.loads(cached_results.decode('utf-8'))
-            dumped = json.dumps(utf8_cache[0])
-            loaded = json.loads(dumped)
-            logger.debug(f"UTF-8 decode is {loaded}")
+            dumped = json.dumps(utf8_cache)
+            logger.debug(f"UTF-8 decode is {dumped}")
             return subscription_obj.sub_response_builder(
-                "EVENT", subscription_obj.subscription_id, loaded, 200
+                "EVENT", subscription_obj.subscription_id, dumped, 200
             )
 
         elif cached_results is None:

--- a/docker/nostpy_relay/event_handler.py
+++ b/docker/nostpy_relay/event_handler.py
@@ -279,8 +279,9 @@ async def handle_subscription(request: Request) -> JSONResponse:
         logger.debug(f"Cached results are {cached_results}")
 
         if cached_results:
+            utf8_cache = json.loads(cached_results.decode('utf-8'))
             return subscription_obj.sub_response_builder(
-                "EVENT", subscription_obj.subscription_id, cached_results, 200
+                "EVENT", subscription_obj.subscription_id, utf8_cache, 200
             )
 
         elif cached_results is None:

--- a/docker/nostpy_relay/event_handler.py
+++ b/docker/nostpy_relay/event_handler.py
@@ -280,6 +280,7 @@ async def handle_subscription(request: Request) -> JSONResponse:
 
         if cached_results:
             utf8_cache = json.loads(cached_results.decode('utf-8'))
+            logger.debug(f"UTF-8 decode is {utf8_cache}")
             return subscription_obj.sub_response_builder(
                 "EVENT", subscription_obj.subscription_id, utf8_cache, 200
             )

--- a/docker/nostpy_relay/event_handler.py
+++ b/docker/nostpy_relay/event_handler.py
@@ -28,7 +28,7 @@ from init_db import initialize_db
 
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.DEBUG)
+logger.setLevel(logging.INFO)
 formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
 handler = logging.StreamHandler()
 handler.setFormatter(formatter)


### PR DESCRIPTION
Changes `if` `cached_results` to `if/elif` logic to resolve #78 and actually return cached results instead of sending false `EOSE` message